### PR TITLE
fix: update pytz version to resolve import warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ python-slugify==8.0.1
 requests==2.31.0
 cloudinary==1.44.1
 bleach==6.2.0
-pytz==2023.4
+pytz==2023.4.post1
 asyncio-compat==0.1.2


### PR DESCRIPTION
- Update pytz from 2023.4 to 2023.4.post1 to match existing requirements
- This should resolve the 'No module named pytz' warning in deployment
- Notification queue should now start properly