### PR TITLE
fix: update server/requirements.txt with missing dependencies

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,7 @@ Flask==2.3.3
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.5
 Flask-CORS==4.0.0
+Flask-Login==0.6.3
 psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 PyJWT==2.8.0
@@ -20,3 +21,5 @@ python-slugify==8.0.1
 requests==2.31.0
 cloudinary==1.44.1
 bleach==6.2.0
+pytz==2023.4.post1
+asyncio-compat==0.1.2


### PR DESCRIPTION
- Add Flask-Login==0.6.3 for notification routes compatibility
- Add pytz==2023.4.post1 for timezone handling in notifications
- Add asyncio-compat==0.1.2 for async notification delivery
- This resolves the 'No module named pytz' deployment warnings
- Notification queue should now start properly on Render