### PR TITLE
fix: remove non-existent asyncio-compat package

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -22,4 +22,3 @@ requests==2.31.0
 cloudinary==1.44.1
 bleach==6.2.0
 pytz==2023.3.post1
-asyncio-compat==0.1.2


### PR DESCRIPTION
- Remove asyncio-compat==0.1.2 as this package doesn't exist
- asyncio is built into Python 3.7+ so no additional package needed
- Keep pytz==2023.3.post1 and Flask-Login==0.6.3 for notification features
- This should resolve all pip install errors during deployment