### PR TITLE
🐛 fix(validators): correct phone number validation regex

### DIFF
--- a/server/utils/validators.py
+++ b/server/utils/validators.py
@@ -84,7 +84,7 @@ def validate_phone_number(phone: str) -> bool:
     if not phone:
         return True  # Phone is optional
     # Allow international format with + and digits, spaces, hyphens
-    pattern = r'^\+?[1-9]\d{6,14}$'$'
+    pattern = r'^\+?[1-9]\d{6,14}$'
     cleaned_phone = re.sub(r'[\s\-\(\)]', '', phone)
     return re.match(pattern, cleaned_phone) is not None
 


### PR DESCRIPTION
- correct regex to remove redundant '$' at the end of the pattern