### PR TITLE
✨ feat(comment): add comment edit and delete features

### DIFF
--- a/client/src/components/posts/CommentSection.jsx
+++ b/client/src/components/posts/CommentSection.jsx
@@ -17,7 +17,7 @@ const CommentSection = ({ postId, comments }) => {
       )}
       <div className="comment-list">
         {comments && comments.length > 0 ? (
-          comments.map(comment => <CommentItem key={comment.id} comment={comment} />)
+          comments.map(comment => <CommentItem key={comment.comment_id || comment.id} comment={comment} />)
         ) : (
           <p>No comments yet. Be the first to share your thoughts!</p>
         )}

--- a/migrations/versions/09c5a19621ad_add_comment_tracking_fields.py
+++ b/migrations/versions/09c5a19621ad_add_comment_tracking_fields.py
@@ -1,0 +1,34 @@
+"""Add comment tracking fields
+
+Revision ID: 09c5a19621ad
+Revises: 
+Create Date: 2025-07-27 15:55:09.103101
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '09c5a19621ad'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add new columns to comments table
+    op.add_column('comments', sa.Column('is_edited', sa.Boolean(), nullable=False, server_default='false'))
+    op.add_column('comments', sa.Column('edit_count', sa.Integer(), nullable=False, server_default='0'))
+    op.add_column('comments', sa.Column('last_edited_at', sa.DateTime(), nullable=True))
+    op.add_column('comments', sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default='false'))
+    op.add_column('comments', sa.Column('deleted_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    # Remove columns if rollback is needed
+    op.drop_column('comments', 'deleted_at')
+    op.drop_column('comments', 'is_deleted')
+    op.drop_column('comments', 'last_edited_at')
+    op.drop_column('comments', 'edit_count')
+    op.drop_column('comments', 'is_edited')

--- a/server/models/post.py
+++ b/server/models/post.py
@@ -144,12 +144,13 @@ class Comment(db.Model):
     parent_comment_id = db.Column(UUID(as_uuid=True), db.ForeignKey('comments.comment_id'), nullable=True)
     content = db.Column(db.Text, nullable=False)
     is_approved = db.Column(db.Boolean, default=True)
-    # Note: These columns don't exist in the current database, so they're commented out
-    # is_edited = db.Column(db.Boolean, default=False, nullable=False)
-    # edit_count = db.Column(db.Integer, default=0, nullable=False)
-    # last_edited_at = db.Column(db.DateTime, nullable=True)
-    # is_deleted = db.Column(db.Boolean, default=False, nullable=False)
-    # deleted_at = db.Column(db.DateTime, nullable=True)
+    # Edit tracking fields
+    is_edited = db.Column(db.Boolean, default=False, nullable=False)
+    edit_count = db.Column(db.Integer, default=0, nullable=False)
+    last_edited_at = db.Column(db.DateTime, nullable=True)
+    # Soft deletion fields
+    is_deleted = db.Column(db.Boolean, default=False, nullable=False)
+    deleted_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     
@@ -169,17 +170,17 @@ class Comment(db.Model):
                 'name': f"{self.user.first_name} {self.user.last_name}",
                 'avatar_url': self.user.avatar_url
             } if self.user else None,
-            'is_edited': getattr(self, 'is_edited', False),
-            'edit_count': getattr(self, 'edit_count', 0),
-            'last_edited_at': self.last_edited_at.isoformat() if hasattr(self, 'last_edited_at') and self.last_edited_at else None,
-            'is_deleted': getattr(self, 'is_deleted', False),
-            'deleted_at': self.deleted_at.isoformat() if hasattr(self, 'deleted_at') and self.deleted_at else None,
+            'is_edited': self.is_edited,
+            'edit_count': self.edit_count,
+            'last_edited_at': self.last_edited_at.isoformat() if self.last_edited_at else None,
+            'is_deleted': self.is_deleted,
+            'deleted_at': self.deleted_at.isoformat() if self.deleted_at else None,
             'created_at': self.created_at.isoformat(),
             'updated_at': self.updated_at.isoformat()
         }
         
         if include_replies:
-            comment_dict['replies'] = [reply.to_dict() for reply in self.replies] if hasattr(self, 'replies') else []
+            comment_dict['replies'] = [reply.to_dict() for reply in self.replies]
         
         return comment_dict
 

--- a/server/services/comment_service.py
+++ b/server/services/comment_service.py
@@ -53,7 +53,7 @@ class CommentService:
                 }
             
             # Check if comment is deleted
-            if comment.is_deleted:
+            if getattr(comment, 'is_deleted', False):
                 return {
                     'success': False,
                     'message': 'Cannot edit deleted comment',
@@ -90,9 +90,10 @@ class CommentService:
             
             # Update comment
             comment.content = new_content.strip()
-            comment.is_edited = True
-            comment.edit_count += 1
-            comment.last_edited_at = datetime.utcnow()
+            setattr(comment, 'is_edited', True)
+            current_edit_count = getattr(comment, 'edit_count', 0)
+            setattr(comment, 'edit_count', current_edit_count + 1)
+            setattr(comment, 'last_edited_at', datetime.utcnow())
             comment.updated_at = datetime.utcnow()
             
             # Save changes
@@ -143,7 +144,7 @@ class CommentService:
                 }
             
             # Check if already deleted
-            if comment.is_deleted:
+            if getattr(comment, 'is_deleted', False):
                 return {
                     'success': False,
                     'message': 'Comment is already deleted',
@@ -167,9 +168,9 @@ class CommentService:
                 self.logger.info(f"Comment {comment_id} hard deleted by user {user_id}")
                 message = 'Comment permanently deleted'
             else:
-                # Soft delete - mark as deleted
-                comment.is_deleted = True
-                comment.deleted_at = datetime.utcnow()
+                # Soft delete - mark as deleted (using setattr since field may not exist)
+                setattr(comment, 'is_deleted', True)
+                setattr(comment, 'deleted_at', datetime.utcnow())
                 comment.updated_at = datetime.utcnow()
                 
                 self.logger.info(f"Comment {comment_id} soft deleted by user {user_id}")
@@ -216,7 +217,7 @@ class CommentService:
                 }
             
             # Check if not deleted
-            if not comment.is_deleted:
+            if not getattr(comment, 'is_deleted', False):
                 return {
                     'success': False,
                     'message': 'Comment is not deleted',
@@ -232,8 +233,8 @@ class CommentService:
                 }
             
             # Restore comment
-            comment.is_deleted = False
-            comment.deleted_at = None
+            setattr(comment, 'is_deleted', False)
+            setattr(comment, 'deleted_at', None)
             comment.updated_at = datetime.utcnow()
             
             db.session.commit()


### PR DESCRIPTION
- add 'is_edited', 'edit_count', 'last_edited_at', 'is_deleted', and 'deleted_at' fields to the Comment model for tracking edits and deletions -【migrations】
- create a migration script to add the new comment tracking fields to the 'comments' table -【client】
- update CommentItem to use comment.comment_id or comment.id as the key -【server】
- implement soft delete functionality, allowing comments to be marked as deleted instead of permanently removing them
- add comment editing functionality, allowing users to modify their comments
- add comment restoration functionality, allowing admins to restore soft-deleted comments
- prevent editing/deletion of already deleted comments